### PR TITLE
Label Get Started wallet download as warthog_extension

### DIFF
--- a/src/components/GetStartedSection.astro
+++ b/src/components/GetStartedSection.astro
@@ -37,10 +37,10 @@ const wallets = [
     guide: "https://docs.warthog.network/guides/wallet/cli/",
   },
   {
-    title: "Browser Extension Wallet",
+    title: "warthog_extension",
     description:
-      "Browser extension for Chrome and Firefox. Mainnet + DeFi testnet, assets, DEX, and activity. Uses public nodes or add your node URL.",
-    // Shipped from extension-update (built browser-wallet). Unzip → Load unpacked.
+      "Browser extension for Chrome and Firefox (warthog_extension.zip). Mainnet + DeFi testnet, assets, DEX, and activity. Unzip → Load unpacked.",
+    // Shipped from extension-update (built browser-wallet). Artifact: warthog_extension.zip
     download: "https://github.com/warthog-network/extension-update/releases",
     guide: "https://docs.warthog.network/guides/wallet/browser-extension-wallet/",
   },


### PR DESCRIPTION
Match the extension-update release artifact name.