### PR TITLE
Fix Browser Node links: browser-node not browser-node-bodega

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
 # Browser Node extension zip lives on the browser-node Netlify site (packaged on deploy).
 # Same path on this site so Get Started / deep links can use a warthog.network-style URL.
-/downloads/warthog-browser-node-extension.zip  https://browser-node-bodega.netlify.app/downloads/warthog-browser-node-extension.zip  302
+/downloads/warthog-browser-node-extension.zip  https://browser-node.netlify.app/downloads/warthog-browser-node-extension.zip  302

--- a/src/components/GetStartedSection.astro
+++ b/src/components/GetStartedSection.astro
@@ -13,7 +13,7 @@ const mobileWalletApk = `https://github.com/warthog-network/mobile-wallet/releas
 const mobileWalletRelease = `https://github.com/warthog-network/mobile-wallet/releases/tag/v${MOBILE_WALLET_VERSION}`;
 
 /** In-browser full node (Netlify). Extension zip is packaged there on deploy. */
-const browserNodeUrl = "https://browser-node-bodega.netlify.app/";
+const browserNodeUrl = "https://browser-node.netlify.app/";
 /** Same-site path → Netlify redirect to browser-node zip (see public/_redirects). */
 const browserNodeExtensionZip = "/downloads/warthog-browser-node-extension.zip";
 


### PR DESCRIPTION
The bodega Netlify site 404s. Point Get Started and extension zip redirect at https://browser-node.netlify.app which is live.